### PR TITLE
Implement optional OpenAI assembly summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ functions
 2. functions의 경우 내부 요소를 파싱하여 .asm 확장자로 변환한다.  
 
 
-3. 별도의 api(따로 지정해 배포한 assembly 전용 요약 프로젝트)를 이용하여 .asm확장자로 변환한 assembly에 대한 자연어 설명을 얻은 뒤 기본 프롬포트에 삽입한다.
+3. 별도의 api(따로 지정해 배포한 assembly 전용 요약 프로젝트)를 이용하여 .asm확장자로 변환한 assembly에 대한 자연어 설명을 얻은 뒤 기본 프롬포트에 삽입한다. `--openai_asm` 플래그를 사용하면 OpenAI API를 이용해 요약한다.
 
 
 4. openAI api를 호출하여 프롬포트의 내용을 통해 yara rule 생성을 요청한다.
@@ -65,6 +65,7 @@ CLI 구현
 Api call
     1. openAI 인증키는 별도의 설정파일에서 관리
     2. 별도의 api(따로 지정해 배포한 assembly 전용 요약 프로젝트)는 인터페이스 형태로 추상화하여 부름. 이 때 요약 호출은 api 호출을 wrapping 하는 class를 선언하여 가시성을 높임
+    3. `--openai_asm` 플래그를 사용하면 OpenAI API(gpt-4o)로 어셈블리 요약을 수행
 ```
 
 ### Test mode

--- a/assembly_api.py
+++ b/assembly_api.py
@@ -1,20 +1,44 @@
 from typing import Optional
 import requests
 
+from utils import call_openai_api
+
 
 class AssemblySummaryClient:
-    """Wrapper for the external assembly summarization API."""
+    """Wrapper for assembly summarization using an API or OpenAI."""
 
-    def __init__(self, api_url: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        api_url: Optional[str] = None,
+        openai_api_key: Optional[str] = None,
+        openai_model: str = "gpt-4o",
+    ) -> None:
         self.api_url = api_url
+        self.openai_api_key = openai_api_key
+        self.openai_model = openai_model
 
     def summarize(self, asm_path: str) -> str:
-        if not self.api_url:
+        """Return a natural language summary for a single assembly file."""
+        if self.api_url:
+            with open(asm_path, "r", encoding="utf-8") as f:
+                files = {"file": f}
+                response = requests.post(self.api_url, files=files, timeout=30)
+            response.raise_for_status()
+            return response.text.strip()
+
+        if self.openai_api_key:
             with open(asm_path, "r", encoding="utf-8") as f:
                 content = f.read()
-            return f"Summary for {asm_path}::\n" + content[:200]
+            max_chars = 8000
+            if len(content) > max_chars:
+                content = content[:max_chars]
+            prompt = (
+                "Summarize the following assembly code in a short sentence:\n\n" + content
+            )
+            return call_openai_api(
+                prompt, api_key=self.openai_api_key, model=self.openai_model
+            )
+
         with open(asm_path, "r", encoding="utf-8") as f:
-            files = {"file": f}
-            response = requests.post(self.api_url, files=files, timeout=30)
-        response.raise_for_status()
-        return response.text.strip()
+            content = f.read()
+        return f"Summary for {asm_path}::\n" + content[:200]

--- a/cli.py
+++ b/cli.py
@@ -169,7 +169,12 @@ def preprocess_binary(path: str) -> str:
     return json_path
 
 
-def run_pipeline(input_path: str, asm_api: Optional[str], test_mode: bool = False) -> None:
+def run_pipeline(
+    input_path: str,
+    asm_api: Optional[str],
+    use_openai_asm: bool = False,
+    test_mode: bool = False,
+) -> None:
     if input_path.lower().endswith(".json"):
         json_path = input_path
     else:
@@ -183,6 +188,7 @@ def run_pipeline(input_path: str, asm_api: Optional[str], test_mode: bool = Fals
         json_path,
         openai_api_key=api_key,
         asm_api_url=asm_api,
+        use_openai_asm=use_openai_asm,
         test_mode=test_mode,
     )
     if result:
@@ -195,14 +201,19 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="YARA rule generation CLI")
     parser.add_argument("input_path", nargs="?")
     parser.add_argument("--asm_api")
+    parser.add_argument(
+        "--openai_asm",
+        action="store_true",
+        help="use OpenAI for assembly summarization",
+    )
     parser.add_argument("--test", action="store_true", help="run in offline test mode")
     args = parser.parse_args()
 
     if args.test or not args.input_path:
         sample_json = os.path.join(os.path.dirname(__file__), "sample.json")
-        run_pipeline(sample_json, args.asm_api, test_mode=True)
+        run_pipeline(sample_json, args.asm_api, use_openai_asm=args.openai_asm, test_mode=True)
     else:
-        run_pipeline(args.input_path, args.asm_api)
+        run_pipeline(args.input_path, args.asm_api, use_openai_asm=args.openai_asm)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add OpenAI summarization support in `AssemblySummaryClient`
- expose `use_openai_asm` flag in pipeline and CLI
- document the new flag and behaviour in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`
- `python pipeline.py --test --openai_asm`

------
https://chatgpt.com/codex/tasks/task_e_6841c771a0f0832e8f338dea80d46a6f